### PR TITLE
Update installation instructions for TA-lib

### DIFF
--- a/docs/getting-started/README.md
+++ b/docs/getting-started/README.md
@@ -22,7 +22,7 @@ Most of them, if not all, are installed on your machine. We provide guides on ho
 
 ## PIP Installation
 
-First install the required dependency packages:
+First make sure you have installed TA-lib's dependencies following its [documentaion](https://github.com/mrjbq7/ta-lib#dependencies). Then install the required dependency packages for Jesse:
 ```
 pip install -r https://raw.githubusercontent.com/jesse-ai/jesse/master/requirements.txt
 ```


### PR DESCRIPTION
TA-lib requires some dependencies to be installed. Otherwise pip will throw errors as follows.

```
    ERROR: Command errored out with exit status 1:
     command: /Users/jiawei/.pyenv/versions/3.8.9/envs/jesse/bin/python3.8 -u -c 'import io, os, sys, setuptools, tokenize; sys.argv[0] = '"'"'/private/var/folders/f6/qbfh324141jd4k9gvtv0895r0000gn/T/pip-install-4yiz76xb/ta-lib_85c20f876dc441f5bd2b9b3feb681d8a/setup.py'"'"'; __file__='"'"'/private/var/folders/f6/qbfh324141jd4k9gvtv0895r0000gn/T/pip-install-4yiz76xb/ta-lib_85c20f876dc441f5bd2b9b3feb681d8a/setup.py'"'"';f = getattr(tokenize, '"'"'open'"'"', open)(__file__) if os.path.exists(__file__) else io.StringIO('"'"'from setuptools import setup; setup()'"'"');code = f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' install --record /private/var/folders/f6/qbfh324141jd4k9gvtv0895r0000gn/T/pip-record-ppo3dx48/install-record.txt --single-version-externally-managed --compile --install-headers /Users/jiawei/.pyenv/versions/3.8.9/envs/jesse/include/site/python3.8/TA-Lib
         cwd: /private/var/folders/f6/qbfh324141jd4k9gvtv0895r0000gn/T/pip-install-4yiz76xb/ta-lib_85c20f876dc441f5bd2b9b3feb681d8a/
```

I updated the doc to illustrate this requirement.